### PR TITLE
[Feature] Record(여행 기록) Entity에서 RecordImage Entity 분리

### DIFF
--- a/src/main/java/com/spot/spotserver/api/record/domain/Record.java
+++ b/src/main/java/com/spot/spotserver/api/record/domain/Record.java
@@ -15,10 +15,6 @@ public class Record extends BaseEntity {
 
     private String description;
 
-    private String imageUrl;
-
-    private Boolean isRepresentative;
-
     private Region region;
 
     @ManyToOne

--- a/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
+++ b/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
@@ -2,6 +2,7 @@ package com.spot.spotserver.api.record.domain;
 
 import jakarta.persistence.*;
 
+@Entity
 public class RecordImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
+++ b/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
@@ -1,0 +1,17 @@
+package com.spot.spotserver.api.record.domain;
+
+import jakarta.persistence.*;
+
+public class RecordImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+
+    private Boolean isRepresentative;
+
+    @ManyToOne
+    @JoinColumn(name = "record_id")
+    private Record record;
+}


### PR DESCRIPTION
### ✏️Describe
하나의 Record(여행 기록)에 최대 10개 까지의 image가 포함될 수 있도록 기능이 수정되어, 이미지를 별도 Entity로 분리

### 🚀Task
- [x] Record(여행 기록) Entity에서 imageUrl, isRepresentative 칼럼 삭제
- [x] RecordImage Entity 생성

### 🔥Related Issue
close #9 