### PR TITLE
[Refactor] Record, RecordImage Entity 수정

### DIFF
--- a/src/main/java/com/spot/spotserver/api/record/domain/Record.java
+++ b/src/main/java/com/spot/spotserver/api/record/domain/Record.java
@@ -3,8 +3,14 @@ package com.spot.spotserver.api.record.domain;
 import com.spot.spotserver.api.user.domain.User;
 import com.spot.spotserver.common.domain.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "record")
+@Getter
+@NoArgsConstructor
 public class Record extends BaseEntity {
 
     @Id
@@ -20,4 +26,12 @@ public class Record extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Builder
+    public Record(String name, String description, Region region, User user) {
+        this.name = name;
+        this.description = description;
+        this.region = region;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
+++ b/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
@@ -14,7 +14,7 @@ public class RecordImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String imageUrl;
+    private String url;
 
     private Boolean isRepresentative;
 
@@ -23,8 +23,8 @@ public class RecordImage {
     private Record record;
 
     @Builder
-    public RecordImage(String imageUrl, Boolean isRepresentative, Record record) {
-        this.imageUrl = imageUrl;
+    public RecordImage(String url, Boolean isRepresentative, Record record) {
+        this.url = url;
         this.isRepresentative = isRepresentative;
         this.record = record;
     }

--- a/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
+++ b/src/main/java/com/spot/spotserver/api/record/domain/RecordImage.java
@@ -1,8 +1,14 @@
 package com.spot.spotserver.api.record.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "record_image")
+@Getter
+@NoArgsConstructor
 public class RecordImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,4 +21,11 @@ public class RecordImage {
     @ManyToOne
     @JoinColumn(name = "record_id")
     private Record record;
+
+    @Builder
+    public RecordImage(String imageUrl, Boolean isRepresentative, Record record) {
+        this.imageUrl = imageUrl;
+        this.isRepresentative = isRepresentative;
+        this.record = record;
+    }
 }


### PR DESCRIPTION
### ✏️Describe
Record, RecordImage Entity에 Builder 패턴 적용
Image 객체의 멤버 변수이므로 image라는 명칭이 중복 사용되는 것을 개선하기 위해 RecordImage Entity의 imageUrl 칼럼명을 url로 변경

### 🚀Task
- [x] Record Entity Builder 패턴 적용
- [x] RecordImage Entity Builder 패턴 적용
- [x] RecordImage Entity의 imageUrl 칼럼명을 url로 변경

### 🔥Related Issue
close #14 