### PR TITLE
[Feature] 특정 Record(여행 기록) 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
+++ b/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
@@ -30,7 +30,7 @@ public class RecordController {
         return ApiResponse.success(SuccessCode.CREATE_RECORD_SUCCESS, recordResponse);
     }
 
-    @GetMapping("/{regionNumber}")
+    @GetMapping("/region/{regionNumber}")
     public ApiResponse<List<RegionalRecordResponse>> getRegionalRecords(@PathVariable int regionNumber) {
         List<RegionalRecordResponse> regionalRecordResponse = this.recordService.getRegionalRecord(Region.values()[regionNumber]);
         return ApiResponse.success(SuccessCode.GET_REGIONAL_RECORDS_SUCCESS, regionalRecordResponse);

--- a/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
+++ b/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
@@ -35,4 +35,10 @@ public class RecordController {
         List<RegionalRecordResponse> regionalRecordResponse = this.recordService.getRegionalRecord(Region.values()[regionNumber]);
         return ApiResponse.success(SuccessCode.GET_REGIONAL_RECORDS_SUCCESS, regionalRecordResponse);
     }
+
+    @GetMapping("/{id}")
+    public ApiResponse<RecordResponse> getRecord(@PathVariable Long id) {
+        RecordResponse recordResponse = this.recordService.getRecord(id);
+        return ApiResponse.success(SuccessCode.GET_RECORD_SUCCESS, recordResponse);
+    }
 }

--- a/src/main/java/com/spot/spotserver/api/record/repository/RecordImageRepository.java
+++ b/src/main/java/com/spot/spotserver/api/record/repository/RecordImageRepository.java
@@ -4,8 +4,10 @@ import com.spot.spotserver.api.record.domain.Record;
 import com.spot.spotserver.api.record.domain.RecordImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RecordImageRepository extends JpaRepository<RecordImage, Long> {
     Optional<RecordImage> findFirstByRecordOrderByIdAsc(Record record);
+    List<RecordImage> findAllByRecord(Record record);
 }

--- a/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
+++ b/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -33,5 +34,10 @@ public class RecordImageService {
     public String getRegionalThumbnailImage(Record record) {
         RecordImage thumbnailImage = this.recordImageRepository.findFirstByRecordOrderByIdAsc(record).orElseThrow();
         return thumbnailImage.getUrl();
+    }
+
+    public List<String> getImages(Record record) {
+        List<RecordImage> recordImages = this.recordImageRepository.findAllByRecord(record);
+        return recordImages.stream().map((RecordImage::getUrl)).toList();
     }
 }

--- a/src/main/java/com/spot/spotserver/api/record/service/RecordService.java
+++ b/src/main/java/com/spot/spotserver/api/record/service/RecordService.java
@@ -1,6 +1,7 @@
 package com.spot.spotserver.api.record.service;
 
 import com.spot.spotserver.api.record.domain.Record;
+import com.spot.spotserver.api.record.domain.RecordImage;
 import com.spot.spotserver.api.record.domain.Region;
 import com.spot.spotserver.api.record.dto.RecordRequest;
 import com.spot.spotserver.api.record.dto.RecordResponse;
@@ -52,5 +53,11 @@ public class RecordService {
         return records.stream()
                 .map((record) -> new RegionalRecordResponse(record, this.recordImageService.getRegionalThumbnailImage(record)))
                 .toList();
+    }
+
+    public RecordResponse getRecord(Long id) {
+        Record record = this.recordRepository.findById(id).orElseThrow();
+        List<String> images = this.recordImageService.getImages(record);
+        return new RecordResponse(record, images);
     }
 }

--- a/src/main/java/com/spot/spotserver/common/payload/SuccessCode.java
+++ b/src/main/java/com/spot/spotserver/common/payload/SuccessCode.java
@@ -22,6 +22,7 @@ public enum SuccessCode {
     UPDATE_PROFILE_SUCCESS(OK, "프로필 이미지가 정상적으로 변경되었습니다."),
     CREATE_RECORD_SUCCESS(OK, "여행 기록이 정상적으로 생성되었습니다."),
     GET_REGIONAL_RECORDS_SUCCESS(OK, "지역별 기록이 정상적으로 조회되었습니다."),
+    GET_RECORD_SUCCESS(OK, "여행 기록이 정상적으로 조회되었습니다."),
     REGISTER_COLOR_SUCCESS(OK, "배경색이 정상적으로 설정되었습니다."),
     UPDATE_COLOR_SUCCESS(OK, "배경색이 정상적으로 변경되었습니다.");
 


### PR DESCRIPTION
### ✏️Describe
특정 Record(여행 기록) 상세 정보 조회 API 구현
Record Id를 경로 변수로 받아, 해당 Record(여행 기록)의 상세 정보 조회

### 🚀Task
- [x] 특정 Record에 포함된 이미지 조회 기능 구현
- [x] 단일 Record 조회 기능 구현
- [x] 지역 별 조회 API 와 겹치지 않게 url 매핑


### 🔥Related Issue
close #4 