### PR TITLE
[Feature] Record(여행 기록) 수정 API 구현

### DIFF
--- a/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
+++ b/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
@@ -3,6 +3,7 @@ package com.spot.spotserver.api.record.controller;
 import com.spot.spotserver.api.record.domain.Region;
 import com.spot.spotserver.api.record.dto.RecordRequest;
 import com.spot.spotserver.api.record.dto.RecordResponse;
+import com.spot.spotserver.api.record.dto.RecordUpdateRequest;
 import com.spot.spotserver.api.record.dto.RegionalRecordResponse;
 import com.spot.spotserver.api.record.service.RecordService;
 import com.spot.spotserver.api.user.domain.User;
@@ -40,5 +41,14 @@ public class RecordController {
     public ApiResponse<RecordResponse> getRecord(@PathVariable Long id) {
         RecordResponse recordResponse = this.recordService.getRecord(id);
         return ApiResponse.success(SuccessCode.GET_RECORD_SUCCESS, recordResponse);
+    }
+
+    @PatchMapping("/{id}")
+    public <T> ApiResponse<T> updateRecord(@PathVariable Long id,
+                                    @RequestPart RecordUpdateRequest recordUpdateRequest,
+                                    @RequestPart List<MultipartFile> addImages,
+                                    @CurrentUser User user) {
+        this.recordService.updateRecord(id, recordUpdateRequest, addImages, user);
+        return ApiResponse.success(SuccessCode.UPDATE_RECORD_SUCCESS);
     }
 }

--- a/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
+++ b/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,8 +46,8 @@ public class RecordController {
 
     @PatchMapping("/{id}")
     public <T> ApiResponse<T> updateRecord(@PathVariable Long id,
-                                    @RequestPart RecordUpdateRequest recordUpdateRequest,
-                                    @RequestPart List<MultipartFile> addImages,
+                                    @RequestPart("recordUpdate") RecordUpdateRequest recordUpdateRequest,
+                                    @RequestPart("addImages") Optional<List<MultipartFile>> addImages,
                                     @CurrentUser User user) {
         this.recordService.updateRecord(id, recordUpdateRequest, addImages, user);
         return ApiResponse.success(SuccessCode.UPDATE_RECORD_SUCCESS);

--- a/src/main/java/com/spot/spotserver/api/record/domain/Record.java
+++ b/src/main/java/com/spot/spotserver/api/record/domain/Record.java
@@ -45,4 +45,12 @@ public class Record extends BaseEntity {
         this.endDate = endDate;
         this.user = user;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/spot/spotserver/api/record/dto/RecordUpdateRequest.java
+++ b/src/main/java/com/spot/spotserver/api/record/dto/RecordUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.spot.spotserver.api.record.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class RecordUpdateRequest {
+    String title;
+
+    String description;
+
+    List<Long> deleteImages;
+}

--- a/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
+++ b/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
@@ -40,4 +40,8 @@ public class RecordImageService {
         List<RecordImage> recordImages = this.recordImageRepository.findAllByRecord(record);
         return recordImages.stream().map((RecordImage::getUrl)).toList();
     }
+
+    public void deleteImage(Long recordImageId) {
+        this.recordImageRepository.deleteById(recordImageId);
+    }
 }

--- a/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
+++ b/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
@@ -36,12 +36,12 @@ public class RecordImageService {
         return thumbnailImage.getUrl();
     }
 
-    public List<String> getImages(Record record) {
+    public List<String> getRecordImages(Record record) {
         List<RecordImage> recordImages = this.recordImageRepository.findAllByRecord(record);
         return recordImages.stream().map((RecordImage::getUrl)).toList();
     }
 
-    public void deleteImage(Long recordImageId) {
+    public void deleteRecordImage(Long recordImageId) {
         this.recordImageRepository.deleteById(recordImageId);
     }
 }

--- a/src/main/java/com/spot/spotserver/api/record/service/RecordService.java
+++ b/src/main/java/com/spot/spotserver/api/record/service/RecordService.java
@@ -5,6 +5,7 @@ import com.spot.spotserver.api.record.domain.RecordImage;
 import com.spot.spotserver.api.record.domain.Region;
 import com.spot.spotserver.api.record.dto.RecordRequest;
 import com.spot.spotserver.api.record.dto.RecordResponse;
+import com.spot.spotserver.api.record.dto.RecordUpdateRequest;
 import com.spot.spotserver.api.record.dto.RegionalRecordResponse;
 import com.spot.spotserver.api.record.repository.RecordRepository;
 import com.spot.spotserver.api.user.domain.User;
@@ -57,7 +58,23 @@ public class RecordService {
 
     public RecordResponse getRecord(Long id) {
         Record record = this.recordRepository.findById(id).orElseThrow();
-        List<String> images = this.recordImageService.getImages(record);
+        List<String> images = this.recordImageService.getRecordImages(record);
         return new RecordResponse(record, images);
+    }
+
+    public void updateRecord(Long id, RecordUpdateRequest recordUpdateRequest, List<MultipartFile> images, User user) {
+        Record updateRecord = this.recordRepository.findById(id).orElseThrow();
+        updateRecord.updateTitle(recordUpdateRequest.getTitle());
+        updateRecord.updateDescription(recordUpdateRequest.getDescription());
+
+        recordUpdateRequest.getDeleteImages().forEach(this.recordImageService::deleteRecordImage);
+
+        images.forEach((image) -> {
+            try {
+                recordImageService.createRecordImage(image, updateRecord, user);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 }

--- a/src/main/java/com/spot/spotserver/common/payload/SuccessCode.java
+++ b/src/main/java/com/spot/spotserver/common/payload/SuccessCode.java
@@ -23,6 +23,7 @@ public enum SuccessCode {
     CREATE_RECORD_SUCCESS(OK, "여행 기록이 정상적으로 생성되었습니다."),
     GET_REGIONAL_RECORDS_SUCCESS(OK, "지역별 기록이 정상적으로 조회되었습니다."),
     GET_RECORD_SUCCESS(OK, "여행 기록이 정상적으로 조회되었습니다."),
+    UPDATE_RECORD_SUCCESS(OK, "여행 기록이 정상적으로 수정되었습니다."),
     REGISTER_COLOR_SUCCESS(OK, "배경색이 정상적으로 설정되었습니다."),
     UPDATE_COLOR_SUCCESS(OK, "배경색이 정상적으로 변경되었습니다.");
 


### PR DESCRIPTION
### ✏️Describe
Record (여행 기록) 수정 API 구현
- Record Id를 경로 변수로 받아, 해당 Record를 식별
- 이름, 설명을 Request body로 받아, 식별한 Record 수정하여 저장
- 삭제된 RecordImage는 식별자를 Reqeust body로 받아, 삭제 수행
- 추가된 RecordImage는 파일을 별도 part로 받아, 추가 수행 


### 🚀Task
- [x] recordImage 삭제 기능 구현
- [x] RecordService에 updateRecord 기능 추가
- [x] deleteImage -> deleteRecordImage로 네이밍 변경
- [x] RecordUpdateRequest DTO 작성
- [x] 여행 기록 Success Code 추가
- [x] Record Entity에 수정 가능 칼럼의 update 메서드 추가
- [x] RecordContorller에 updateRecord 기능 추가


### 🔥Related Issue
close #5 