### PR TITLE
[Feature] 대표 이미지 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
+++ b/src/main/java/com/spot/spotserver/api/record/controller/RecordController.java
@@ -65,4 +65,10 @@ public class RecordController {
         RepresentativeImageResponse representativeImageResponse = this.representativeImageService.createRepresentativeImage(representativeImageRequest, user);
         return ApiResponse.success(SuccessCode.CREATE_REPRESENTATIVE_IMAGE_SUCCESS, representativeImageResponse);
     }
+
+    @GetMapping("/representative")
+    public ApiResponse<List<RepresentativeImageResponse>> getRepresentativeImages() {
+        List<RepresentativeImageResponse> representativeImageResponses = this.representativeImageService.getRepresentativeImages();
+        return ApiResponse.success(SuccessCode.GET_REPRESENTATIVE_IMAGE_SUCCESS, representativeImageResponses);
+    }
 }

--- a/src/main/java/com/spot/spotserver/api/record/dto/RepresentativeImageResponse.java
+++ b/src/main/java/com/spot/spotserver/api/record/dto/RepresentativeImageResponse.java
@@ -6,11 +6,14 @@ import lombok.Data;
 
 @Data
 public class RepresentativeImageResponse {
+    private Long id;
+
     private Region region;
 
     private String url;
 
     public RepresentativeImageResponse(RepresentativeImage representativeImage) {
+        this.id = representativeImage.getId();
         this.region = representativeImage.getRegion();
         this.url = representativeImage.getUrl();
     }

--- a/src/main/java/com/spot/spotserver/api/record/service/RepresentativeImageService.java
+++ b/src/main/java/com/spot/spotserver/api/record/service/RepresentativeImageService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,5 +27,12 @@ public class RepresentativeImageService {
 
         RepresentativeImage savedRepresentativeImage = this.representativeImageRepository.save(newRepresentativeImage);
         return new RepresentativeImageResponse(savedRepresentativeImage);
+    }
+
+    public List<RepresentativeImageResponse> getRepresentativeImages() {
+        return this.representativeImageRepository.findAll()
+                .stream()
+                .map(RepresentativeImageResponse::new)
+                .toList();
     }
 }


### PR DESCRIPTION
### ✏️Describe
특정 User의 모든 대표 이미지를 조회하는 API

### 🚀Task
- [x] 대표 이미지 전체 조회 기능 구현
- [x] RepresentativeImageResponse DTO에 id 추가
- [x] 대표 이미지 전체 조회 API url 매핑

### 🔥Related Issue
close #52 