### PR TITLE
[Feature] 각 촬영지(spot)의 상세정보 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	//openfeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.github.openfeign:feign-micrometer'
+	implementation 'io.github.openfeign:feign-jackson:12.3'
 
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/spot/spotserver/api/spot/client/CommonInfoClient.java
+++ b/src/main/java/com/spot/spotserver/api/spot/client/CommonInfoClient.java
@@ -1,0 +1,23 @@
+package com.spot.spotserver.api.spot.client;
+
+import com.spot.spotserver.api.spot.dto.response.CommonInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "commonInfoClient", url = "https://apis.data.go.kr/B551011/KorService1")
+public interface CommonInfoClient {
+
+    @GetMapping("/detailCommon1")
+    CommonInfoResponse getCommonInfo(@RequestParam("MobileOS") String MobileOS,
+                                     @RequestParam("MobileApp") String MobileApp,
+                                     @RequestParam("_type") String _type,
+                                     @RequestParam("contentId") String contentId,
+                                     @RequestParam("defaultYN") String defaultYN,
+                                     @RequestParam("firstImageYN") String firstImageYN,
+                                     @RequestParam("addrinfoYN") String addrinfoYN,
+                                     @RequestParam("mapinfoYN") String mapinfoYN,
+                                     @RequestParam("overviewYN") String overviewYN,
+                                     @RequestParam("serviceKey") String serviceKey
+    );
+}

--- a/src/main/java/com/spot/spotserver/api/spot/controller/SpotController.java
+++ b/src/main/java/com/spot/spotserver/api/spot/controller/SpotController.java
@@ -1,7 +1,25 @@
 package com.spot.spotserver.api.spot.controller;
 
+import com.spot.spotserver.api.spot.dto.response.SpotDetailsResponse;
+import com.spot.spotserver.api.spot.service.SpotService;
+import com.spot.spotserver.common.payload.ApiResponse;
+import com.spot.spotserver.common.payload.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class SpotController {
+
+    private final SpotService spotService;
+
+    @GetMapping("/spot/{contentId}")
+    public ApiResponse<SpotDetailsResponse> getSpotDetails(@PathVariable Integer contentId) {
+        SpotDetailsResponse result = spotService.getSpotDetails(contentId);
+        return ApiResponse.success(SuccessCode.GET_SPOT_DETAIL_SUCCESS, result);
+    }
 }

--- a/src/main/java/com/spot/spotserver/api/spot/dto/response/CommonInfoResponse.java
+++ b/src/main/java/com/spot/spotserver/api/spot/dto/response/CommonInfoResponse.java
@@ -1,0 +1,35 @@
+package com.spot.spotserver.api.spot.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record CommonInfoResponse(Response response) {
+
+    public record Response(@JsonProperty("body") ResponseBody body) {
+    }
+
+    public record ResponseBody(@JsonProperty("items") Items items) {
+    }
+
+    public record Items(@JsonProperty("item") List<Item> item) {
+    }
+
+    public record Item(
+            @JsonProperty("contentid") String contentid,
+            @JsonProperty("contenttypeid") String contenttypeid,
+            @JsonProperty("title") String title,
+            @JsonProperty("firstimage") String firstimage,
+            @JsonProperty("firstimage2") String firstimage2,
+            @JsonProperty("homepage") String homepage,
+            @JsonProperty("tel") String tel,
+            @JsonProperty("addr1") String addr1,
+            @JsonProperty("addr2") String addr2,
+            @JsonProperty("zipcode") String zipcode,
+            @JsonProperty("mapx") String mapx,
+            @JsonProperty("mapy") String mapy,
+            @JsonProperty("overview") String overview,
+            @JsonProperty("mlevel") String mlevel
+    ) {
+    }
+}

--- a/src/main/java/com/spot/spotserver/api/spot/dto/response/SpotDetailsResponse.java
+++ b/src/main/java/com/spot/spotserver/api/spot/dto/response/SpotDetailsResponse.java
@@ -1,0 +1,33 @@
+package com.spot.spotserver.api.spot.dto.response;
+
+public record SpotDetailsResponse(
+        String contentId,
+        String contentTypeId,
+        String title,
+        String image,
+        String homepage,
+        String tel,
+        String addr1,       // 주소
+        String addr2,       // 상세주소
+        String zipcode,     // 우편번호
+        String longtitude,
+        String latitude,
+        String overview
+) {
+    public static SpotDetailsResponse fromCommonInfo(CommonInfoResponse.Item item) {
+        return new SpotDetailsResponse(
+                item.contentid(),
+                item.contenttypeid(),
+                item.title(),
+                item.firstimage() != null ? item.firstimage() : item.firstimage2(), // 첫 번째 이미지가 없으면 대체 이미지 사용
+                item.homepage(),
+                item.tel(),
+                item.addr1(),
+                item.addr2(),
+                item.zipcode(),
+                item.mapx(),
+                item.mapy(),
+                item.overview()
+        );
+    }
+}

--- a/src/main/java/com/spot/spotserver/api/spot/service/SpotService.java
+++ b/src/main/java/com/spot/spotserver/api/spot/service/SpotService.java
@@ -1,7 +1,35 @@
 package com.spot.spotserver.api.spot.service;
 
+import com.spot.spotserver.api.spot.client.CommonInfoClient;
+import com.spot.spotserver.api.spot.dto.response.CommonInfoResponse;
+import com.spot.spotserver.api.spot.dto.response.SpotDetailsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class SpotService {
+
+    private final CommonInfoClient commonInfoClient;
+
+    @Value("${tourApi.serviceKey}")
+    private String serviceKey;
+    private static final String mobileOS = "AND";
+    private static final String mobileApp = "SPOT";
+    private static final String _type = "json";
+
+    public SpotDetailsResponse getSpotDetails(Integer contentId) {
+
+        CommonInfoResponse commonInfo = commonInfoClient.getCommonInfo(
+                mobileOS, mobileApp, _type, contentId.toString(), "Y", "Y", "Y", "Y", "Y", serviceKey
+        );
+
+        if (commonInfo == null || commonInfo.response().body().items().item().isEmpty()) {
+            throw new IllegalArgumentException("데이터가 없습니다.");
+        }
+
+        SpotDetailsResponse spotDetailsResponse = SpotDetailsResponse.fromCommonInfo(commonInfo.response().body().items().item().get(0));
+        return spotDetailsResponse;
+    }
 }

--- a/src/main/java/com/spot/spotserver/common/payload/SuccessCode.java
+++ b/src/main/java/com/spot/spotserver/common/payload/SuccessCode.java
@@ -22,8 +22,6 @@ public enum SuccessCode {
     UPDATE_PROFILE_SUCCESS(OK, "프로필 이미지가 정상적으로 변경되었습니다."),
     REGISTER_COLOR_SUCCESS(OK, "배경색이 정상적으로 설정되었습니다."),
     UPDATE_COLOR_SUCCESS(OK, "배경색이 정상적으로 변경되었습니다."),
-      REGISTER_COLOR_SUCCESS(OK, "배경색이 정상적으로 설정되었습니다."),
-    UPDATE_COLOR_SUCCESS(OK, "배경색이 정상적으로 변경되었습니다."),
     GET_PROFILE_SUCCESS(OK,"프로필이 정상적으로 조회되었습니다."),
     CREATE_RECORD_SUCCESS(OK, "여행 기록이 정상적으로 생성되었습니다."),
     GET_REGIONAL_RECORDS_SUCCESS(OK, "지역별 기록이 정상적으로 조회되었습니다."),
@@ -32,7 +30,8 @@ public enum SuccessCode {
     DELETE_RECORD_SUCCESS(OK, "여행 기록이 정상적으로 삭제되었습니다."),
     CREATE_REPRESENTATIVE_IMAGE_SUCCESS(OK, "대표 이미지가 정상적으로 생성되었습니다."),
     GET_REPRESENTATIVE_IMAGE_SUCCESS(OK, "대표 이미지가 정상적으로 조회되었습니다."),
-    UPDATE_REPRESENTATIVE_IMAGE_SUCCESS(OK, "대표 이미지가 정상적으로 수정되었습니다.");
+    UPDATE_REPRESENTATIVE_IMAGE_SUCCESS(OK, "대표 이미지가 정상적으로 수정되었습니다."),
+    GET_SPOT_DETAIL_SUCCESS(OK, "스팟 상세 정보가 정상적으로 조회되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/spot/spotserver/config/FeignConfig.java
+++ b/src/main/java/com/spot/spotserver/config/FeignConfig.java
@@ -1,0 +1,28 @@
+package com.spot.spotserver.config;
+
+import feign.Logger;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public Encoder feignEncoder() {
+        return new JacksonEncoder();
+    }
+
+    @Bean
+    public Decoder feignDecoder() {
+        return new JacksonDecoder();
+    }
+
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;  // 전체 로그 출력 설정
+    }
+}


### PR DESCRIPTION
### ✏️Describe
관광공사 API를 통해 각 촬영지(spot)의 상세정보 조회 구현

### 🚀Task
- [x] OpenAPI 사용을 위한 Client 생성
- [x] 상세정보 조회 관련 DTO 생성
- [x] SpotService 작성
- [x] SpotController 작성


### 🔥Related Issue
close #33 