### PR TITLE
[Fix] Schedule 생성 요청 application/octet-stream' is not supported 에러 해결

### DIFF
--- a/src/main/java/com/spot/spotserver/api/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/spot/spotserver/api/schedule/controller/ScheduleController.java
@@ -25,10 +25,9 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     @PostMapping("")
-    public ApiResponse<ScheduleResponse> createSchedule(@RequestPart("schedule") ScheduleRequest scheduleRequest,
-                                                        @RequestPart MultipartFile image,
+    public ApiResponse<ScheduleResponse> createSchedule(@ModelAttribute ScheduleRequest scheduleRequest,
                                                         @CurrentUser User user) throws IOException {
-        ScheduleResponse scheduleResponse = this.scheduleService.createSchedule(scheduleRequest, image, user);
+        ScheduleResponse scheduleResponse = this.scheduleService.createSchedule(scheduleRequest, user);
         return ApiResponse.success(SuccessCode.CREATE_SCHEDULE_SUCCESS, scheduleResponse);
     }
 

--- a/src/main/java/com/spot/spotserver/api/schedule/dto/request/ScheduleRequest.java
+++ b/src/main/java/com/spot/spotserver/api/schedule/dto/request/ScheduleRequest.java
@@ -4,6 +4,7 @@ import com.spot.spotserver.common.domain.City;
 import com.spot.spotserver.common.domain.Region;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -17,6 +18,8 @@ public class ScheduleRequest {
     private LocalDate startDate;
 
     private LocalDate endDate;
+
+    private MultipartFile image;
 
     public void setRegion(int region) {
         this.region = Region.values()[region];


### PR DESCRIPTION
### ✏️Describe
- Record에서 발생한 문제를 아래 방법으로 해결하는데 성공했기 때문에, Schedule에도 적용
-  Content-Type 'application/octet-stream' is not supported 에러 해결
- 리액트 네이티브에서 Multipart/form-data 요청 처리 문제 발생

### 🚀Task
- [x] ScheduleRequest DTO 변경
- [x] Request 받는 형식 `@RequestPart` -> `@ModelAttribute`로 변경

### 🔥Related Issue
close #122 