### PR TITLE
[Bug] 일정 생성 중, Location의 일자 별 배치 오류 해결

### DIFF
--- a/src/main/java/com/spot/spotserver/api/schedule/service/ScheduleService.java
+++ b/src/main/java/com/spot/spotserver/api/schedule/service/ScheduleService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Service
@@ -86,7 +87,7 @@ public class ScheduleService {
     @Transactional
     public LocationResponse createLocation(LocationRequest locationRequest) {
         Schedule schedule = this.scheduleRepository.findById(locationRequest.getScheduleId()).orElseThrow();
-        Integer day = this.locationRepository.countBySchedule(schedule);
+        Integer day = this.locationRepository.countBySchedule(schedule) % (int) ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()) + 1;
         Integer seq = this.locationRepository.countByScheduleAndDay(schedule, day);
 
         Location newLocation = Location.builder()


### PR DESCRIPTION
### ✏️Describe
- 일정에 장소 추가 중, Location의 일자 별 배치 오류 해결
- 정해진 일자를 넘어서 Location이 배치되는 문제 발생
- 모듈러 연산을 통해 범위 제한

### 🚀Task
- [x] 일정에 장소 추가 시, 모듈러 연산을 통해 범위 제한

### 🔥Related Issue
close #131 