### PR TITLE
[Feature] API spec 변경에 따른 '여행 기록 이미지 수정 API' 변경 기능 구현

### DIFF
--- a/src/main/java/com/spot/spotserver/api/record/dto/RecordUpdateRequest.java
+++ b/src/main/java/com/spot/spotserver/api/record/dto/RecordUpdateRequest.java
@@ -12,5 +12,5 @@ public class RecordUpdateRequest {
 
     String description;
 
-    List<Long> deleteImages;
+    List<String> deleteImages;
 }

--- a/src/main/java/com/spot/spotserver/api/record/repository/RecordImageRepository.java
+++ b/src/main/java/com/spot/spotserver/api/record/repository/RecordImageRepository.java
@@ -11,4 +11,6 @@ public interface RecordImageRepository extends JpaRepository<RecordImage, Long> 
     Optional<RecordImage> findFirstByRecordOrderByIdAsc(Record record);
     List<RecordImage> findAllByRecord(Record record);
     void deleteAllByRecord(Record record);
+    boolean existsByUrl(String url);
+    void deleteByUrl(String url);
 }

--- a/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
+++ b/src/main/java/com/spot/spotserver/api/record/service/RecordImageService.java
@@ -53,11 +53,11 @@ public class RecordImageService {
     }
 
     @Transactional
-    public void deleteRecordImageById(Long recordImageId) {
-        if (!this.recordImageRepository.existsById(recordImageId)) {
+    public void deleteRecordImageById(String recordImageId) {
+        if (!this.recordImageRepository.existsByUrl(recordImageId)) {
             throw new RecordImageNotFoundException(ErrorCode.RECORD_IMAGE_NOT_FOUND);
         }
-        this.recordImageRepository.deleteById(recordImageId);
+        this.recordImageRepository.deleteByUrl(recordImageId);
     }
 
     @Transactional


### PR DESCRIPTION
### ✏️Describe
- API spec 변경에 따른 '여행 기록 이미지 수정 API' 변경 기능 구현
- deleteImages를 id가 아닌 imageUrl로 변경해달라는 요청을 받아, 이에 맞춰 수정

### 🚀Task
- [x] RecordUpdateRequest의 deleteImages Type을 String으로 변경
- [x] RecordImageRepository에 existsByUrl, deleteByUrl 추가 작성
- [x] 여행 기록 이미지 수정 기능 호출 메서드 변경

### 🔥Related Issue
close #130 