### PR TITLE
[Fix] 촬영지 상세 정보 조회 시, contentId가 동일한 데이터로 인해 발생하는 NonUniqueResultException 문제 해결

### DIFF
--- a/src/main/java/com/spot/spotserver/api/spot/controller/SpotController.java
+++ b/src/main/java/com/spot/spotserver/api/spot/controller/SpotController.java
@@ -19,8 +19,10 @@ public class SpotController {
     private final SpotService spotService;
 
     @GetMapping("/spot/{contentId}")
-    public ApiResponse<SpotDetailsResponse> getSpotDetails(@PathVariable Integer contentId, @CurrentUser User user) {
-        SpotDetailsResponse result = spotService.getSpotDetails(contentId, user);
+    public ApiResponse<SpotDetailsResponse> getSpotDetails(@PathVariable Integer contentId,
+                                                           @RequestParam Long workId,
+                                                           @CurrentUser User user) {
+        SpotDetailsResponse result = spotService.getSpotDetails(contentId, workId, user);
         return ApiResponse.success(SuccessCode.GET_SPOT_DETAIL_SUCCESS, result);
     }
 

--- a/src/main/java/com/spot/spotserver/api/spot/dto/response/SpotDetailsResponse.java
+++ b/src/main/java/com/spot/spotserver/api/spot/dto/response/SpotDetailsResponse.java
@@ -29,13 +29,10 @@ public record SpotDetailsResponse(
         Integer likeCount,
         String posterUrl
 ) {
-    public static SpotDetailsResponse fromCommonInfo(CommonInfoResponse.Item item, SpotRepository spotRepository, LikesRepository likesRepository, User user) {
+    public static SpotDetailsResponse fromCommonInfo(CommonInfoResponse.Item item, Spot spot, LikesRepository likesRepository, User user) {
 
-        Optional<Spot> spot = Optional.ofNullable(spotRepository.findByContentId(Integer.parseInt(item.contentid()))
-                .orElseThrow(() -> new SpotNotFoundException(ErrorCode.SPOT_NOT_FOUND)));
-
-        Boolean isLiked = likesRepository.findByUserAndSpot(user, spot.get()).isPresent();
-        Integer likeCount = likesRepository.countBySpot(spot.get());
+        Boolean isLiked = likesRepository.findByUserAndSpot(user, spot).isPresent();
+        Integer likeCount = likesRepository.countBySpot(spot);
 
         return new SpotDetailsResponse(
                 item.contentid(),
@@ -47,14 +44,14 @@ public record SpotDetailsResponse(
                 item.addr1(),
                 item.addr2(),
                 item.zipcode(),
-                spot.get().getRegion() != null ? spot.get().getRegion().ordinal() : null,
-                spot.get().getCity() != null ? spot.get().getCity().ordinal() : null,
+                spot.getRegion() != null ? spot.getRegion().ordinal() : null,
+                spot.getCity() != null ? spot.getCity().ordinal() : null,
                 item.mapx(),
                 item.mapy(),
                 item.overview(),
                 isLiked,
                 likeCount,
-                spot.get().getWork().getPosterUrl()
+                spot.getWork().getPosterUrl()
         );
     }
 }

--- a/src/main/java/com/spot/spotserver/api/spot/repository/SpotRepository.java
+++ b/src/main/java/com/spot/spotserver/api/spot/repository/SpotRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 
 public interface SpotRepository extends JpaRepository<Spot, Long> {
     Optional<Spot> findByContentId(Integer contentId);
+    Optional<Spot> findByContentIdAndWorkId(Integer contentId, Long workId);
     List<Spot> findByWorkId(Long workId);
 }

--- a/src/main/java/com/spot/spotserver/api/spot/service/SpotService.java
+++ b/src/main/java/com/spot/spotserver/api/spot/service/SpotService.java
@@ -50,7 +50,7 @@ public class SpotService {
     private static final String mobileApp = "SPOT";
     private static final String _type = "json";
 
-    public SpotDetailsResponse getSpotDetails(Integer contentId, User user) {
+    public SpotDetailsResponse getSpotDetails(Integer contentId, Long workId, User user) {
 
         CommonInfoResponse commonInfo = commonInfoClient.getCommonInfo(
                 mobileOS, mobileApp, _type, contentId.toString(), "Y", "Y", "Y", "Y", "Y", serviceKey
@@ -60,7 +60,12 @@ public class SpotService {
             throw new IllegalArgumentException("데이터가 없습니다.");
         }
 
-        SpotDetailsResponse spotDetailsResponse = SpotDetailsResponse.fromCommonInfo(commonInfo.response().body().items().item().get(0), spotRepository, likesRepository, user);
+        Spot spot = spotRepository.findByContentIdAndWorkId(contentId, workId)
+                .orElseThrow(() -> new SpotNotFoundException(ErrorCode.SPOT_NOT_FOUND));
+
+        SpotDetailsResponse spotDetailsResponse = SpotDetailsResponse.fromCommonInfo(
+                commonInfo.response().body().items().item().get(0), spot, likesRepository, user);
+
         return spotDetailsResponse;
     }
 


### PR DESCRIPTION
### ✏️Describe
촬영지 상세 정보 조회 시, contentId가 동일한 데이터로 인해 발생하는 NonUniqueResultException 문제 해결


### 🚀Task
- [x] SpotRepository findByContentIdAndWorkId 추가
- [x] SpotDetailsResponse 코드 수정
- [x] SpotService 코드 수정
- [x] SpotController 코드 수정


### 🔥Related Issue
close #135 