### PR TITLE
[Fix] 주변 장소 조회 시, contentId가 동일한 데이터로 인해 발생하는 NonUniqueResultException 문제 해결 

### DIFF
--- a/src/main/java/com/spot/spotserver/api/spot/controller/SpotController.java
+++ b/src/main/java/com/spot/spotserver/api/spot/controller/SpotController.java
@@ -34,8 +34,9 @@ public class SpotController {
     }
 
     @GetMapping("/spot/{contentId}/arounds")
-    public ApiResponse<SpotAroundResponse> getSpotAroundList(@PathVariable Integer contentId) {
-        SpotAroundResponse result = spotService.getSpotAroundList(contentId);
+    public ApiResponse<SpotAroundResponse> getSpotAroundList(@PathVariable Integer contentId,
+                                                             @RequestParam Long workId) {
+        SpotAroundResponse result = spotService.getSpotAroundList(contentId, workId);
         return ApiResponse.success(SuccessCode.GET_SPOT_AROUND_SUCCESS, result);
     }
 

--- a/src/main/java/com/spot/spotserver/api/spot/service/SpotService.java
+++ b/src/main/java/com/spot/spotserver/api/spot/service/SpotService.java
@@ -103,11 +103,12 @@ public class SpotService {
         return EARTH_RADIUS * angularDistance;
     }
 
-    public SpotAroundResponse getSpotAroundList(Integer contentId) {
+    public SpotAroundResponse getSpotAroundList(Integer contentId, Long workId) {
 
-        Optional<Spot> spot = Optional.ofNullable(spotRepository.findByContentId(contentId).orElseThrow(() -> new IllegalArgumentException("해당하는 촬영지가 존재하지 않습니다.")));
-        Double longitude = spot.get().getLongitude();
-        Double latitude = spot.get().getLatitude();
+        Spot spot = spotRepository.findByContentIdAndWorkId(contentId, workId)
+                .orElseThrow(() -> new SpotNotFoundException(ErrorCode.SPOT_NOT_FOUND));
+        Double longitude = spot.getLongitude();
+        Double latitude = spot.getLatitude();
 
         LocationBasedResponse attractionResponse;
         LocationBasedResponse restaurantResponse;


### PR DESCRIPTION
### ✏️Describe
주변 장소 조회 시, contentId가 동일한 데이터로 인해 발생하는 NonUniqueResultException 문제 해결 

### 🚀Task
- [x] 주변 장소 조회 시, workId 비교 로직 추가


### 🔥Related Issue
close #135 