### PR TITLE
[Fix] 토큰 재발급 시 발생하는 401 에러 해결

### DIFF
--- a/src/main/java/com/spot/spotserver/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/spot/spotserver/api/auth/jwt/JwtAuthenticationFilter.java
@@ -28,10 +28,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-        // 로그인 요청인지 확인
-        // TODO 애플로그인 구현 후 추가
+
         String requestURI = request.getRequestURI();
-        if ("/api/login/kakao".equals(requestURI)) {
+        if ("/api/login/kakao".equals(requestURI) || "/api/refresh".equals(requestURI)) {
             // 로그인 요청의 경우 JWT 검증 건너뜀
             filterChain.doFilter(request, response);
             return;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,12 @@ spring:
     active: dev
     include:
       - secret
+
+logging:
+  level:
+    org:
+      springframework:
+        security: DEBUG
+    com:
+      spot:
+        spotserver: DEBUG


### PR DESCRIPTION
### ✏️Describe
토큰 재발급 시 발생하는 401 에러 해결

### 🚀Task
- [x] JwtAuthenticationFilter "/api/refresh"인지 확인하여 JWT 검증 생략하는 로직 추가


### 🔥Related Issue
close #160 