### PR TITLE
[Refactor] Badge를 Region 단위에서 City 단위로 수정

### DIFF
--- a/src/main/java/com/spot/spotserver/api/quiz/domain/Badge.java
+++ b/src/main/java/com/spot/spotserver/api/quiz/domain/Badge.java
@@ -1,5 +1,6 @@
 package com.spot.spotserver.api.quiz.domain;
 
+import com.spot.spotserver.common.domain.City;
 import com.spot.spotserver.common.domain.Region;
 import com.spot.spotserver.api.user.domain.User;
 import com.spot.spotserver.common.domain.BaseEntity;
@@ -21,20 +22,18 @@ public class Badge extends BaseEntity {
     @Enumerated(EnumType.ORDINAL)
     private Region region;
 
-    private Integer count = 0;
+    @Enumerated(EnumType.ORDINAL)
+    private City city;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
     @Builder
-    public Badge(Long id, Region region, User user) {
+    public Badge(Long id, Region region, City city, User user) {
         this.id = id;
         this.region = region;
+        this.city = city;
         this.user = user;
-    }
-
-    public void addBadge() {
-        this.count++;
     }
 }

--- a/src/main/java/com/spot/spotserver/api/quiz/repository/BadgeRepository.java
+++ b/src/main/java/com/spot/spotserver/api/quiz/repository/BadgeRepository.java
@@ -1,6 +1,7 @@
 package com.spot.spotserver.api.quiz.repository;
 
 import com.spot.spotserver.api.quiz.domain.Badge;
+import com.spot.spotserver.common.domain.City;
 import com.spot.spotserver.common.domain.Region;
 import com.spot.spotserver.api.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
-    Optional<Badge> findAllByUserAndRegion(User user, Region region);
     List<Badge> findByUser(User user);
+    Integer countByUserAndRegion(User user, Region region);
+    boolean existsByUserAndCity(User user, City city);
 }

--- a/src/main/java/com/spot/spotserver/api/quiz/service/QuizService.java
+++ b/src/main/java/com/spot/spotserver/api/quiz/service/QuizService.java
@@ -28,13 +28,12 @@ public class QuizService {
         Quiz quiz = this.quizRepository.findById(id).orElseThrow();
         boolean isCorrect = quiz.isCorrect(answer);
 
-        if (isCorrect) {
-            Badge badge = this.badgeRepository.findAllByUserAndRegion(user, quiz.getSpot().getRegion())
-                    .orElseGet(() -> Badge.builder()
-                            .region(quiz.getSpot().getRegion())
-                            .user(user)
-                            .build());
-            badge.addBadge();
+        if (isCorrect && !this.badgeRepository.existsByUserAndCity(user, quiz.getSpot().getCity())) {
+            Badge badge = Badge.builder()
+                    .region(quiz.getSpot().getRegion())
+                    .city(quiz.getSpot().getCity())
+                    .user(user)
+                    .build();
             this.badgeRepository.save(badge);
         }
 

--- a/src/main/java/com/spot/spotserver/api/user/domain/User.java
+++ b/src/main/java/com/spot/spotserver/api/user/domain/User.java
@@ -52,13 +52,7 @@ public class User extends BaseEntity {
         this.color = color;
     }
 
-    public int getBadgeCount() {
-        return badges.stream().mapToInt(Badge::getCount).sum();
-    }
-
-    public void updateProfileLevel() {
-        int badgeCount = getBadgeCount();
-
+    public void updateProfileLevel(Integer badgeCount) {
         if (badgeCount <= 5) {
             this.profileLevel = ProfileLevel.BEGINNER;
         } else if (badgeCount <= 12) {

--- a/src/main/java/com/spot/spotserver/api/user/service/UserService.java
+++ b/src/main/java/com/spot/spotserver/api/user/service/UserService.java
@@ -154,7 +154,7 @@ public class UserService {
 
         for (Badge badge : badges) {
             int regionOrdinal = badge.getRegion().ordinal();
-            userBadges.set(regionOrdinal, new UserBadgeResponse(regionOrdinal, badge.getCount()));
+            userBadges.set(regionOrdinal, new UserBadgeResponse(regionOrdinal, this.badgeRepository.countByUserAndRegion(user, badge.getRegion())));
         }
         return  userBadges;
     }


### PR DESCRIPTION
### ✏️Describe
- 추가 요구사항에 따라, 기능을 수정하기 위해 Badge를 Region 단위에서 City 단위로 수정
- 이에 따라, Badge의 `count` 칼럼 삭제 및 User의 `getBadgeCount()` 삭제
- Badge의 기존 칼럼들을 사용하던 기능을 변경에 맞춰 수정

### 🚀Task
- [x] Badge, User Entity 수정
- [x] 기존 회원 등급 업데이트 기능 수정
- [x] 기존 퀴즈 정답 시, Badge 부여 기능 수정

### 🔥Related Issue
close #173 