### PR TITLE
[Feature] 광역시, 특별시 뱃지 개수의 상한선을 5개로 조정

### DIFF
--- a/src/main/java/com/spot/spotserver/api/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/spot/spotserver/api/badge/repository/BadgeRepository.java
@@ -12,6 +12,6 @@ public interface BadgeRepository extends JpaRepository<Badge, Long> {
     List<Badge> findByUser(User user);
     Integer countByUser(User user);
     Integer countByUserAndRegion(User user, Region region);
-    boolean existsByUserAndCity(User user, City city);
+    Integer countByUserAndCity(User user, City city);
     List<Badge> findByUserAndRegionIn(User user, List<Region> regions);
 }

--- a/src/main/java/com/spot/spotserver/common/domain/MajorCity.java
+++ b/src/main/java/com/spot/spotserver/common/domain/MajorCity.java
@@ -1,0 +1,5 @@
+package com.spot.spotserver.common.domain;
+
+public enum MajorCity {
+    SEOUL, BUSAN, GWANGJU_GWANGYEOKSI, DAEJEON, DAEGU, SAEJOENG, ULSAN, INCHEON,
+}


### PR DESCRIPTION
### ✏️Describe
- 기존 1개였던 광역시, 특별시 뱃지 개수의 상한선을 5개로 조정

### 🚀Task
- [x] MajorCity Enum 작성
- [x] MajorCity의 뱃지 개수 상한선 5개로 상향 조정

### 🔥Related Issue
close #207